### PR TITLE
fix typedefinition

### DIFF
--- a/config-ini.d.ts
+++ b/config-ini.d.ts
@@ -139,4 +139,4 @@ declare class ConfigIniParser {
 	};
 }
 
-export = ConfigIniParser;
+export = {ConfigIniParser};


### PR DESCRIPTION
because the import statement is currently
```js
const ConfigIniParser = require("config-ini-parser").ConfigIniParser;
```
and not
```js
const ConfigIniParser = require("config-ini-parser");
```